### PR TITLE
Add test to validate mcu.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Cowneck
+
+## Running tests
+
+Use Python's built-in `unittest` module to run the tests:
+
+```bash
+python -m unittest tests/test_mcu_json.py
+```

--- a/tests/test_mcu_json.py
+++ b/tests/test_mcu_json.py
@@ -1,0 +1,21 @@
+import json
+import os
+import unittest
+
+class TestMCUJson(unittest.TestCase):
+    def setUp(self):
+        # Load the JSON file once for tests
+        json_path = os.path.join(os.path.dirname(__file__), '..', 'mcu.json')
+        with open(json_path, 'r', encoding='utf-8') as f:
+            self.data = json.load(f)
+
+    def test_parses_valid_json(self):
+        # If setUp succeeds, JSON is valid
+        self.assertIsInstance(self.data, list)
+
+    def test_unique_ids(self):
+        ids = [entry.get('id') for entry in self.data]
+        self.assertEqual(len(ids), len(set(ids)), "Duplicate id values found")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add minimal test to ensure `mcu.json` loads and ids are unique
- document how to run the test with `unittest`
- remove extraneous line from README

## Testing
- `python -m unittest tests/test_mcu_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68443a1aed088333aab28c9d109c94fb